### PR TITLE
Rollback dconv to an older version

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -49,6 +49,7 @@ jobs:
         fetch-depth: 0
         repository: cbonte/haproxy-dconv
         path: dconv
+        ref: 369783df0454f7e632e1d8ffad51ae50f935ed95
     - name: Install dconv dependencies.
       run: |
         pip3 install -r dconv/requirements.txt


### PR DESCRIPTION
haproxy-dconv current master (77d5cba) doesn't work correctly, this commit fix the checkout of an older version (369783d)